### PR TITLE
Refactored code and fixed two-player graph and product construction

### DIFF
--- a/src/graph/dfa.py
+++ b/src/graph/dfa.py
@@ -55,10 +55,10 @@ class DFAGraph(Graph):
             self.add_state(_s)
 
             # add init and accepting node attribute
-            if _s == "T0_init":
+            if _s.endswith("init"):
                 self.add_initial_state(_s)
 
-            if _s == "accept_all":
+            if _s.startswith("accept"):
                 self.add_accepting_state(_s)
 
         # add edges
@@ -164,7 +164,7 @@ class DFAGraph(Graph):
         :return: A tuple of states, edges and accepting states
         """
 
-        spot_output = run_spot(formula=sc_ltl)
+        spot_output = run_spot(formula=sc_ltl, debug=True)
         edges = parse_ltl(spot_output)
         (states, initial, accepts) = find_states(edges)
 

--- a/src/graph/two_player_graph.py
+++ b/src/graph/two_player_graph.py
@@ -365,6 +365,7 @@ class TwoPlayerGraphBuilder(Builder):
         :return: A concrete/active instance of the TwoPlayerGraph
         """
         self._instance = TwoPlayerGraph(graph_name, config_yaml, save_flag)
+        self._instance._graph = nx.MultiDiGraph(name=graph_name)
 
         graph_yaml = None
         if from_file:
@@ -373,7 +374,8 @@ class TwoPlayerGraphBuilder(Builder):
         if graph_yaml is None and minigrid is not None:
             graph_yaml = self._from_minigrid(minigrid, n_step)
 
-        self._instance.construct_graph(graph_yaml)
+        if graph_yaml:
+            self._instance.construct_graph(graph_yaml)
 
         if plot:
             self._instance.plot_graph(view=view, format=format)


### PR DESCRIPTION
src/graph/product.py: Added flag to distinguish PDFA product construction from two-player game based product construction. Fixed minor function argument and variable assignment bugs.

src/graph/two_player_graph.py: Refactored code to initialize an instance of DiGraph and only then call construct_graph function.